### PR TITLE
feat / Complete templating and styling for chat

### DIFF
--- a/SwivelMobile.xcodeproj/project.pbxproj
+++ b/SwivelMobile.xcodeproj/project.pbxproj
@@ -825,6 +825,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = SwivelMobile/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = SwivelSystems.SwivelMobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -840,6 +841,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = SwivelMobile/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = SwivelSystems.SwivelMobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/SwivelMobile/Base.lproj/Main.storyboard
+++ b/SwivelMobile/Base.lproj/Main.storyboard
@@ -24,6 +24,10 @@
             <string>Roboto-Bold</string>
             <string>Roboto-Bold</string>
             <string>Roboto-Bold</string>
+            <string>Roboto-Bold</string>
+            <string>Roboto-Bold</string>
+            <string>Roboto-Bold</string>
+            <string>Roboto-Bold</string>
         </mutableArray>
         <mutableArray key="Roboto-Medium.ttf">
             <string>Roboto-Medium</string>
@@ -42,8 +46,12 @@
             <string>Roboto-Regular</string>
             <string>Roboto-Regular</string>
             <string>Roboto-Regular</string>
+            <string>Roboto-Regular</string>
+            <string>Roboto-Regular</string>
+            <string>Roboto-Regular</string>
         </mutableArray>
         <mutableArray key="Simple-Line-Icons.ttf">
+            <string>Simple-Line-Icons</string>
             <string>Simple-Line-Icons</string>
             <string>Simple-Line-Icons</string>
             <string>Simple-Line-Icons</string>
@@ -71,7 +79,7 @@
                                 <color key="backgroundColor" red="0.96078431372549022" green="0.96078431372549022" blue="0.96078431372549022" alpha="1" colorSpace="calibratedRGB"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="cell" rowHeight="107" id="XlJ-f2-FqN" customClass="AnnouncementCell" customModule="SwivelMobile" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="92" width="343" height="107"/>
+                                        <rect key="frame" x="0.0" y="72" width="343" height="107"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="XlJ-f2-FqN" id="FPa-f1-z7U">
                                             <rect key="frame" x="0.0" y="0.0" width="343" height="107"/>
@@ -314,13 +322,82 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="56F-qc-P0M" customClass="KDCircularProgress" customModule="SwivelMobile" customModuleProvider="target">
+                                <rect key="frame" x="91" y="93" width="192" height="178"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="%" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l1E-Pa-Obo">
+                                        <rect key="frame" x="58" y="63" width="76" height="51"/>
+                                        <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="17"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstItem="l1E-Pa-Obo" firstAttribute="leading" secondItem="56F-qc-P0M" secondAttribute="leading" constant="58" id="ISI-1v-TlD"/>
+                                    <constraint firstItem="l1E-Pa-Obo" firstAttribute="top" secondItem="56F-qc-P0M" secondAttribute="top" constant="63" id="Po8-hD-PQG"/>
+                                    <constraint firstItem="l1E-Pa-Obo" firstAttribute="centerX" secondItem="56F-qc-P0M" secondAttribute="centerX" id="haK-oF-FdE"/>
+                                    <constraint firstItem="l1E-Pa-Obo" firstAttribute="centerY" secondItem="56F-qc-P0M" secondAttribute="centerY" id="i66-6I-EGO"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="angle">
+                                        <real key="value" value="100"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="startAngle">
+                                        <real key="value" value="-90"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="clockwise" value="YES"/>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="glowAmount">
+                                        <real key="value" value="0.0"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="gradientRotateSpeed">
+                                        <real key="value" value="1"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="IBColor1">
+                                        <color key="value" red="0.1803921568627451" green="0.80000000000000004" blue="0.44313725490196076" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="lerpColorMode" value="NO"/>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="roundedCorners" value="NO"/>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="trackThickness">
+                                        <real key="value" value="0.69999999999999996"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="progressThickness">
+                                        <real key="value" value="0.69999999999999996"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="trackColor">
+                                        <color key="value" red="1" green="0.014874841749999999" blue="0.1621566451" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="  MY GRADES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mzP-dv-6pL">
+                                <rect key="frame" x="0.0" y="300" width="375" height="43"/>
+                                <color key="backgroundColor" red="0.96078431369999995" green="0.96078431369999995" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                <fontDescription key="fontDescription" name="Roboto-Bold" family="Roboto" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" progress="1" translatesAutoresizingMaskIntoConstraints="NO" id="6cl-on-ic9" userLabel="Seperator Line">
+                                <rect key="frame" x="5" y="342" width="365" height="2"/>
+                                <color key="progressTintColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                            </progressView>
+                            <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" progress="1" translatesAutoresizingMaskIntoConstraints="NO" id="6rN-y3-qwb" userLabel="Shadow">
+                                <rect key="frame" x="6" y="344" width="363" height="2"/>
+                                <color key="progressTintColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                            </progressView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f6G-NS-flq">
+                                <rect key="frame" x="0.0" y="264" width="375" height="39"/>
+                                <color key="backgroundColor" red="0.96078431369999995" green="0.96078431369999995" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                <fontDescription key="fontDescription" name="Roboto-Bold" family="Roboto" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" rowHeight="57" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="EgA-kG-R33">
                                 <rect key="frame" x="0.0" y="264" width="375" height="403"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <inset key="separatorInset" minX="15" minY="0.0" maxX="15" maxY="0.0"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="cell" rowHeight="57" id="uRI-RI-k89" customClass="GradesCell" customModule="SwivelMobile">
-                                        <rect key="frame" x="0.0" y="72" width="375" height="57"/>
+                                        <rect key="frame" x="0.0" y="28" width="375" height="57"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="uRI-RI-k89" id="8Kk-Uv-hiL">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="56.5"/>
@@ -379,95 +456,28 @@
                                     <outlet property="delegate" destination="8rJ-Kc-sve" id="dpR-Y2-7g8"/>
                                 </connections>
                             </tableView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="56F-qc-P0M" customClass="KDCircularProgress" customModule="SwivelMobile" customModuleProvider="target">
-                                <rect key="frame" x="91" y="93" width="192" height="178"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="%" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l1E-Pa-Obo">
-                                        <rect key="frame" x="58" y="63" width="76" height="51"/>
-                                        <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="17"/>
-                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <constraints>
-                                    <constraint firstItem="l1E-Pa-Obo" firstAttribute="leading" secondItem="56F-qc-P0M" secondAttribute="leading" constant="58" id="Kbm-26-EN8"/>
-                                    <constraint firstItem="l1E-Pa-Obo" firstAttribute="top" secondItem="56F-qc-P0M" secondAttribute="top" constant="63" id="kOw-UJ-ph2"/>
-                                    <constraint firstItem="l1E-Pa-Obo" firstAttribute="centerY" secondItem="56F-qc-P0M" secondAttribute="centerY" id="qLp-Lt-ffC"/>
-                                    <constraint firstItem="l1E-Pa-Obo" firstAttribute="centerX" secondItem="56F-qc-P0M" secondAttribute="centerX" id="wfM-Nj-VEA"/>
-                                </constraints>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="angle">
-                                        <real key="value" value="100"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="startAngle">
-                                        <real key="value" value="-90"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="boolean" keyPath="clockwise" value="YES"/>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="glowAmount">
-                                        <real key="value" value="0.0"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="gradientRotateSpeed">
-                                        <real key="value" value="1"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="IBColor1">
-                                        <color key="value" red="0.1803921568627451" green="0.80000000000000004" blue="0.44313725490196076" alpha="1" colorSpace="calibratedRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="boolean" keyPath="lerpColorMode" value="NO"/>
-                                    <userDefinedRuntimeAttribute type="boolean" keyPath="roundedCorners" value="NO"/>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="trackThickness">
-                                        <real key="value" value="0.69999999999999996"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="progressThickness">
-                                        <real key="value" value="0.69999999999999996"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="trackColor">
-                                        <color key="value" red="1" green="0.014874841749999999" blue="0.1621566451" alpha="1" colorSpace="calibratedRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                            </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="  MY GRADES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mzP-dv-6pL">
-                                <rect key="frame" x="0.0" y="300" width="375" height="43"/>
-                                <color key="backgroundColor" red="0.96078431369999995" green="0.96078431369999995" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
-                                <fontDescription key="fontDescription" name="Roboto-Bold" family="Roboto" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" fixedFrame="YES" progress="1" translatesAutoresizingMaskIntoConstraints="NO" id="6cl-on-ic9" userLabel="Seperator Line">
-                                <rect key="frame" x="5" y="342" width="365" height="2"/>
-                                <color key="progressTintColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
-                            </progressView>
-                            <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" fixedFrame="YES" progress="1" translatesAutoresizingMaskIntoConstraints="NO" id="6rN-y3-qwb" userLabel="Shadow">
-                                <rect key="frame" x="6" y="344" width="363" height="2"/>
-                                <color key="progressTintColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
-                            </progressView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f6G-NS-flq">
-                                <rect key="frame" x="0.0" y="264" width="375" height="39"/>
-                                <color key="backgroundColor" red="0.96078431369999995" green="0.96078431369999995" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
-                                <fontDescription key="fontDescription" name="Roboto-Bold" family="Roboto" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                         </subviews>
                         <color key="backgroundColor" red="0.96078431372549022" green="0.96078431372549022" blue="0.96078431372549022" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstAttribute="bottom" secondItem="56F-qc-P0M" secondAttribute="bottom" constant="396" id="43l-rV-wbf"/>
+                            <constraint firstItem="56F-qc-P0M" firstAttribute="leading" secondItem="QS5-Rx-YEW" secondAttribute="leadingMargin" constant="75" id="1A2-FG-YO6"/>
+                            <constraint firstItem="56F-qc-P0M" firstAttribute="centerX" secondItem="f6G-NS-flq" secondAttribute="centerX" id="3sp-Fv-NmC"/>
                             <constraint firstItem="f6G-NS-flq" firstAttribute="leading" secondItem="QS5-Rx-YEW" secondAttribute="leading" id="747-M5-Cvo"/>
                             <constraint firstItem="f6G-NS-flq" firstAttribute="trailing" secondItem="EgA-kG-R33" secondAttribute="trailing" id="7f6-qs-oYn"/>
-                            <constraint firstItem="56F-qc-P0M" firstAttribute="top" secondItem="L7p-HK-0SC" secondAttribute="bottom" constant="49" id="E3k-AN-V3h"/>
-                            <constraint firstItem="56F-qc-P0M" firstAttribute="leading" secondItem="QS5-Rx-YEW" secondAttribute="leadingMargin" constant="75" id="HV3-Ox-wur"/>
+                            <constraint firstItem="56F-qc-P0M" firstAttribute="centerX" secondItem="6rN-y3-qwb" secondAttribute="centerX" id="8Ge-gr-W1j"/>
+                            <constraint firstItem="56F-qc-P0M" firstAttribute="top" secondItem="L7p-HK-0SC" secondAttribute="bottom" constant="49" id="Egg-SR-SV1"/>
                             <constraint firstItem="Djb-ko-YwX" firstAttribute="top" secondItem="EgA-kG-R33" secondAttribute="bottom" id="L6R-F4-oaI"/>
-                            <constraint firstItem="56F-qc-P0M" firstAttribute="centerX" secondItem="EgA-kG-R33" secondAttribute="centerX" id="Pwh-Ig-Zdq"/>
+                            <constraint firstAttribute="bottom" secondItem="56F-qc-P0M" secondAttribute="bottom" constant="396" id="MFP-9P-1cG"/>
                             <constraint firstItem="mzP-dv-6pL" firstAttribute="leading" secondItem="f6G-NS-flq" secondAttribute="leading" id="S4J-Vq-LUI"/>
                             <constraint firstAttribute="trailingMargin" secondItem="EgA-kG-R33" secondAttribute="trailing" constant="-20" id="TgM-Kq-xNF"/>
-                            <constraint firstItem="mzP-dv-6pL" firstAttribute="top" secondItem="56F-qc-P0M" secondAttribute="bottom" constant="31" id="Uj6-Ht-YrQ"/>
                             <constraint firstItem="EgA-kG-R33" firstAttribute="leading" secondItem="QS5-Rx-YEW" secondAttribute="leadingMargin" constant="-20" id="aAf-uu-glN"/>
                             <constraint firstItem="f6G-NS-flq" firstAttribute="top" secondItem="L7p-HK-0SC" secondAttribute="bottom" constant="220" id="aJJ-69-R6d"/>
                             <constraint firstAttribute="trailing" secondItem="f6G-NS-flq" secondAttribute="trailing" id="dNE-ax-Kkn"/>
                             <constraint firstItem="f6G-NS-flq" firstAttribute="leading" secondItem="EgA-kG-R33" secondAttribute="leading" id="e3X-wo-R9X"/>
+                            <constraint firstItem="mzP-dv-6pL" firstAttribute="top" secondItem="56F-qc-P0M" secondAttribute="bottom" constant="29" id="eBa-Mx-qPw"/>
                             <constraint firstItem="f6G-NS-flq" firstAttribute="top" secondItem="EgA-kG-R33" secondAttribute="top" id="p3Q-JG-Mse"/>
                             <constraint firstItem="mzP-dv-6pL" firstAttribute="trailing" secondItem="f6G-NS-flq" secondAttribute="trailing" id="qs9-iT-hdF"/>
                             <constraint firstItem="Djb-ko-YwX" firstAttribute="top" secondItem="mzP-dv-6pL" secondAttribute="bottom" constant="322" id="rhn-kc-U0p"/>
+                            <constraint firstItem="56F-qc-P0M" firstAttribute="centerX" secondItem="6cl-on-ic9" secondAttribute="centerX" id="sJX-ik-eVw"/>
                             <constraint firstItem="Djb-ko-YwX" firstAttribute="top" secondItem="f6G-NS-flq" secondAttribute="bottom" constant="364" id="zVd-Oy-gFE"/>
                         </constraints>
                     </view>
@@ -640,6 +650,267 @@
             </objects>
             <point key="canvasLocation" x="-1958.5" y="1106.5"/>
         </scene>
+        <!--View Controller-->
+        <scene sceneID="yWQ-3e-26B">
+            <objects>
+                <viewController id="AJj-4E-gvl" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="lk5-qb-LZu"/>
+                        <viewControllerLayoutGuide type="bottom" id="Zne-Nm-OrA"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="rMy-c8-0ta">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aRm-yS-dmh">
+                                <rect key="frame" x="321" y="67" width="51" height="31"/>
+                            </switch>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="59" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="FIJ-cx-Ifl">
+                                <rect key="frame" x="77" y="131" width="298" height="536"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="sectionIndexBackgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" rowHeight="59" id="kqv-IP-sfB">
+                                        <rect key="frame" x="0.0" y="28" width="298" height="59"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="kqv-IP-sfB" id="4jA-aX-2kC">
+                                            <rect key="frame" x="0.0" y="0.0" width="298" height="58.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" image="profile_icon-1" translatesAutoresizingMaskIntoConstraints="NO" id="TOs-OT-ffo">
+                                                    <rect key="frame" x="8" y="11" width="34" height="36"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="34" id="Ofb-lo-5ZS"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Hey man you must be done thesis" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U3d-u2-KQl">
+                                                    <rect key="frame" x="50" y="28" width="183" height="16"/>
+                                                    <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="10"/>
+                                                    <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="40mins ago" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qep-aY-Hj7">
+                                                    <rect key="frame" x="221" y="15" width="63" height="13"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="63" id="vpx-r7-Ner"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="9"/>
+                                                    <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="X" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HzI-IP-7Dj">
+                                                    <rect key="frame" x="266" y="25" width="18" height="21"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="18" id="8rw-1k-ptb"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="13"/>
+                                                    <color key="textColor" red="0.20392156859999999" green="0.59607843140000005" blue="0.85882352939999995" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Joel Arguero" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GJN-ah-FfW">
+                                                    <rect key="frame" x="50" y="11" width="163" height="20"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="163" id="Bwg-SQ-laa"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" name="Roboto-Bold" family="Roboto" pointSize="14"/>
+                                                    <color key="textColor" red="0.20392156859999999" green="0.59607843140000005" blue="0.85882352939999995" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="Qep-aY-Hj7" firstAttribute="leading" secondItem="GJN-ah-FfW" secondAttribute="trailing" constant="8" symbolic="YES" id="5bw-bc-9TU"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="Qep-aY-Hj7" secondAttribute="trailing" constant="8" id="BMq-eo-5Jh"/>
+                                                <constraint firstItem="TOs-OT-ffo" firstAttribute="leading" secondItem="4jA-aX-2kC" secondAttribute="leadingMargin" id="Bsh-tK-rBp"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="U3d-u2-KQl" secondAttribute="bottom" constant="2.5" id="KJl-3C-7tK"/>
+                                                <constraint firstItem="HzI-IP-7Dj" firstAttribute="leading" secondItem="U3d-u2-KQl" secondAttribute="trailing" constant="33" id="PyU-eX-hfT"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="Qep-aY-Hj7" secondAttribute="trailing" constant="21" id="Xlm-aj-W9I"/>
+                                                <constraint firstItem="U3d-u2-KQl" firstAttribute="firstBaseline" secondItem="HzI-IP-7Dj" secondAttribute="firstBaseline" id="Yjg-dM-5R4"/>
+                                                <constraint firstItem="TOs-OT-ffo" firstAttribute="top" secondItem="GJN-ah-FfW" secondAttribute="top" id="cNG-IL-Hiw"/>
+                                                <constraint firstItem="GJN-ah-FfW" firstAttribute="leading" secondItem="U3d-u2-KQl" secondAttribute="leading" id="cQ2-RP-Ujp"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="TOs-OT-ffo" secondAttribute="bottom" constant="-0.5" id="eIL-3H-cXj"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="Qep-aY-Hj7" secondAttribute="trailing" constant="6" id="iPt-db-Ulm"/>
+                                                <constraint firstItem="U3d-u2-KQl" firstAttribute="centerY" secondItem="HzI-IP-7Dj" secondAttribute="centerY" id="kTw-28-984"/>
+                                                <constraint firstItem="TOs-OT-ffo" firstAttribute="top" secondItem="4jA-aX-2kC" secondAttribute="top" id="o3Z-1q-t18"/>
+                                                <constraint firstItem="GJN-ah-FfW" firstAttribute="centerY" secondItem="Qep-aY-Hj7" secondAttribute="centerY" id="scs-hR-Ysv"/>
+                                                <constraint firstItem="U3d-u2-KQl" firstAttribute="top" secondItem="Qep-aY-Hj7" secondAttribute="bottom" id="si6-cb-Vlc"/>
+                                                <constraint firstItem="Qep-aY-Hj7" firstAttribute="trailing" secondItem="HzI-IP-7Dj" secondAttribute="trailing" id="uYO-8G-Jf8"/>
+                                                <constraint firstItem="GJN-ah-FfW" firstAttribute="leading" secondItem="TOs-OT-ffo" secondAttribute="trailing" constant="8" symbolic="YES" id="vQF-I6-WQa"/>
+                                                <constraint firstItem="Qep-aY-Hj7" firstAttribute="baseline" secondItem="GJN-ah-FfW" secondAttribute="firstBaseline" id="wpd-JC-GT7"/>
+                                                <constraint firstItem="Qep-aY-Hj7" firstAttribute="top" secondItem="4jA-aX-2kC" secondAttribute="topMargin" constant="-4" id="zTX-iY-YEJ"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Jonathen Chen" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Hq-QE-nuX">
+                                <rect key="frame" x="115" y="67" width="126" height="31"/>
+                                <fontDescription key="fontDescription" name="Roboto-Bold" family="Roboto" pointSize="17"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="rqL-2I-9SD">
+                                <rect key="frame" x="77" y="103" width="298" height="29"/>
+                                <color key="backgroundColor" red="0.20392156859999999" green="0.59607843140000005" blue="0.85882352939999995" alpha="1" colorSpace="calibratedRGB"/>
+                                <segments>
+                                    <segment title="All"/>
+                                    <segment title="Online"/>
+                                </segments>
+                                <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <connections>
+                                    <segue destination="1Pn-Ou-pxt" kind="custom" customClass="SWRevealViewControllerSeguePushController" id="ldx-FN-K2d"/>
+                                </connections>
+                            </segmentedControl>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="profile_icon-1" translatesAutoresizingMaskIntoConstraints="NO" id="gpL-iG-hc3">
+                                <rect key="frame" x="77" y="67" width="32" height="31"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="32" id="9Ex-L8-Vjh"/>
+                                </constraints>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Messages" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p1Z-fR-wtl">
+                                <rect key="frame" x="77" y="28" width="245" height="32"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="32" id="TFF-ll-Jc8"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" name="Roboto-Bold" family="Roboto" pointSize="20"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="X" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Ks-ao-Pv5">
+                                <rect key="frame" x="339" y="32" width="31" height="26"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="31" id="VD5-Hm-AfQ"/>
+                                    <constraint firstAttribute="height" constant="26" id="tLS-4B-EY0"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" name="Simple-Line-Icons" family="Simple-Line-Icons" pointSize="18"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" red="0.20392156859999999" green="0.59607843140000005" blue="0.85882352939999995" alpha="1" colorSpace="calibratedRGB"/>
+                        <constraints>
+                            <constraint firstItem="FIJ-cx-Ifl" firstAttribute="leading" secondItem="rqL-2I-9SD" secondAttribute="leading" id="00R-dU-XP1"/>
+                            <constraint firstItem="FIJ-cx-Ifl" firstAttribute="top" secondItem="rqL-2I-9SD" secondAttribute="bottom" id="1gF-eH-ge6"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="aRm-yS-dmh" secondAttribute="trailing" constant="-11" id="3Aw-g0-unU"/>
+                            <constraint firstItem="5Ks-ao-Pv5" firstAttribute="top" secondItem="lk5-qb-LZu" secondAttribute="bottom" constant="12" id="40I-RW-Xrn"/>
+                            <constraint firstItem="gpL-iG-hc3" firstAttribute="top" secondItem="4Hq-QE-nuX" secondAttribute="top" id="Aia-n8-xw1"/>
+                            <constraint firstItem="5Ks-ao-Pv5" firstAttribute="leading" secondItem="p1Z-fR-wtl" secondAttribute="trailing" constant="17" id="GwQ-sj-HCt"/>
+                            <constraint firstItem="4Hq-QE-nuX" firstAttribute="leading" secondItem="gpL-iG-hc3" secondAttribute="trailing" constant="6" id="HDs-qJ-UNX"/>
+                            <constraint firstItem="5Ks-ao-Pv5" firstAttribute="firstBaseline" secondItem="p1Z-fR-wtl" secondAttribute="firstBaseline" id="Hri-UA-D2L"/>
+                            <constraint firstItem="p1Z-fR-wtl" firstAttribute="leading" secondItem="rMy-c8-0ta" secondAttribute="leadingMargin" constant="61" id="L8R-tL-ysF"/>
+                            <constraint firstItem="gpL-iG-hc3" firstAttribute="top" secondItem="p1Z-fR-wtl" secondAttribute="bottom" constant="7" id="Mcg-Rq-QGu"/>
+                            <constraint firstItem="gpL-iG-hc3" firstAttribute="leading" secondItem="rqL-2I-9SD" secondAttribute="leading" id="NDa-jP-VCY"/>
+                            <constraint firstItem="rqL-2I-9SD" firstAttribute="top" secondItem="gpL-iG-hc3" secondAttribute="bottom" constant="5" id="QOy-ib-Ywf"/>
+                            <constraint firstItem="4Hq-QE-nuX" firstAttribute="top" secondItem="aRm-yS-dmh" secondAttribute="top" id="S68-b0-CmY"/>
+                            <constraint firstItem="gpL-iG-hc3" firstAttribute="bottom" secondItem="4Hq-QE-nuX" secondAttribute="bottom" id="SZd-rP-fRf"/>
+                            <constraint firstItem="gpL-iG-hc3" firstAttribute="leading" secondItem="p1Z-fR-wtl" secondAttribute="leading" id="Z7l-no-8bX"/>
+                            <constraint firstItem="4Hq-QE-nuX" firstAttribute="bottom" secondItem="aRm-yS-dmh" secondAttribute="bottom" id="gDs-22-dfW"/>
+                            <constraint firstItem="aRm-yS-dmh" firstAttribute="trailing" secondItem="5Ks-ao-Pv5" secondAttribute="trailing" id="gy9-Sa-krh"/>
+                            <constraint firstAttribute="trailing" secondItem="rqL-2I-9SD" secondAttribute="trailing" id="k0F-Ip-wc3"/>
+                            <constraint firstItem="FIJ-cx-Ifl" firstAttribute="trailing" secondItem="rqL-2I-9SD" secondAttribute="trailing" id="mYK-w2-Sbe"/>
+                            <constraint firstItem="FIJ-cx-Ifl" firstAttribute="bottom" secondItem="Zne-Nm-OrA" secondAttribute="top" id="qeX-TU-aJL"/>
+                            <constraint firstItem="aRm-yS-dmh" firstAttribute="leading" secondItem="4Hq-QE-nuX" secondAttribute="trailing" constant="80" id="v5g-Ll-aQV"/>
+                        </constraints>
+                    </view>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Cd8-IV-mgz" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-3168.5" y="1114.5"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="ZLv-e6-dcC">
+            <objects>
+                <viewController id="1Pn-Ou-pxt" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="w4O-HZ-BrC"/>
+                        <viewControllerLayoutGuide type="bottom" id="qUY-yk-ARn"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Vk2-4c-I2t">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="70f-dv-Cr2">
+                                <rect key="frame" x="0.0" y="20" width="375" height="29"/>
+                                <fontDescription key="fontDescription" name="Roboto-Bold" family="Roboto" pointSize="22"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tcP-bY-oKd">
+                                <rect key="frame" x="0.0" y="54" width="375" height="613"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lId-5P-7Vn">
+                                        <rect key="frame" x="0.0" y="575" width="375" height="38"/>
+                                        <subviews>
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ugz-9S-aia">
+                                                <rect key="frame" x="15" y="4" width="304" height="30"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Send" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NzB-HS-Myf">
+                                                <rect key="frame" x="327" y="4" width="48" height="30"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    </view>
+                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="65" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="At7-ff-IEe">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="575"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <prototypes>
+                                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" rowHeight="65" id="1Yd-mf-bJL">
+                                                <rect key="frame" x="0.0" y="28" width="375" height="65"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="1Yd-mf-bJL" id="fX1-gP-KXA">
+                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="64.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <subviews>
+                                                        <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="where we gonna go eat?" translatesAutoresizingMaskIntoConstraints="NO" id="WQE-6u-MUT">
+                                                            <rect key="frame" x="73" y="8" width="281" height="48.5"/>
+                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                            <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                                        </textView>
+                                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hIU-pl-5ev">
+                                                            <rect key="frame" x="13" y="0.0" width="52" height="43.5"/>
+                                                        </imageView>
+                                                    </subviews>
+                                                </tableViewCellContentView>
+                                            </tableViewCell>
+                                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" rowHeight="83" id="6hb-PO-tXe">
+                                                <rect key="frame" x="0.0" y="93" width="375" height="83"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="6hb-PO-tXe" id="wjM-Cf-4Dt">
+                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="82.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <subviews>
+                                                        <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="Lets go eat " translatesAutoresizingMaskIntoConstraints="NO" id="LG4-eV-YKE">
+                                                            <rect key="frame" x="8" y="17" width="291" height="48.5"/>
+                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                            <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                                        </textView>
+                                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aw6-Br-geR">
+                                                            <rect key="frame" x="315" y="8" width="52" height="43.5"/>
+                                                        </imageView>
+                                                    </subviews>
+                                                </tableViewCellContentView>
+                                            </tableViewCell>
+                                        </prototypes>
+                                    </tableView>
+                                </subviews>
+                            </scrollView>
+                        </subviews>
+                        <color key="backgroundColor" red="0.20392156859999999" green="0.59607843140000005" blue="0.85882352939999995" alpha="1" colorSpace="calibratedRGB"/>
+                    </view>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Bqm-o8-WAy" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-2962.5" y="2005.5"/>
+        </scene>
         <!--Main Menu Controller-->
         <scene sceneID="1ta-nr-37W">
             <objects>
@@ -767,35 +1038,6 @@
             </objects>
             <point key="canvasLocation" x="-1192.5" y="247.5"/>
         </scene>
-        <!--Table View Controller-->
-        <scene sceneID="nTa-1p-NeC">
-            <objects>
-                <tableViewController id="Tmz-a1-JwU" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="QUu-CW-Ku7">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="Ie1-T6-Sce">
-                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Ie1-T6-Sce" id="pLM-BR-FcB">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                        </prototypes>
-                        <connections>
-                            <outlet property="dataSource" destination="Tmz-a1-JwU" id="NUJ-wg-Vvy"/>
-                            <outlet property="delegate" destination="Tmz-a1-JwU" id="9dz-5D-Myr"/>
-                        </connections>
-                    </tableView>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="g2c-Yn-6CJ" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-3192.5" y="1120.5"/>
-        </scene>
         <!--Landing Page Controller-->
         <scene sceneID="BxD-F7-1Tj">
             <objects>
@@ -841,7 +1083,7 @@
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Swivel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rBP-Ar-BpK">
                                 <rect key="frame" x="134" y="188" width="107" height="31"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="107" id="BEH-vg-Sfo"/>
+                                    <constraint firstAttribute="width" constant="107" id="cP4-aM-k5r"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" name="Nunito-ExtraBold" family="Nunito" pointSize="34"/>
                                 <nil key="highlightedColor"/>
@@ -866,6 +1108,9 @@
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Educational Software" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yct-Tj-QZY">
                                 <rect key="frame" x="106" y="235" width="169" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="21" id="nAo-pC-oTj"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" name="Nunito-Regular" family="Nunito" pointSize="17"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
@@ -915,39 +1160,39 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="yct-Tj-QZY" firstAttribute="top" secondItem="rBP-Ar-BpK" secondAttribute="bottom" constant="16" id="1Up-3b-s4z"/>
                             <constraint firstItem="xUd-Xg-GOt" firstAttribute="leading" secondItem="GCv-8F-b0y" secondAttribute="leadingMargin" constant="50" id="32T-Gc-WP9"/>
-                            <constraint firstItem="yct-Tj-QZY" firstAttribute="top" secondItem="GCv-8F-b0y" secondAttribute="top" constant="235" id="53P-hx-rnT"/>
+                            <constraint firstItem="rBP-Ar-BpK" firstAttribute="centerX" secondItem="GCv-8F-b0y" secondAttribute="centerX" id="4hn-oN-LGi"/>
                             <constraint firstItem="eM9-99-Rvk" firstAttribute="leading" secondItem="0o8-8J-LZM" secondAttribute="trailing" id="6Jz-yS-Lfp"/>
                             <constraint firstItem="K6U-4C-ls1" firstAttribute="trailing" secondItem="jU0-d0-NoL" secondAttribute="trailing" id="84b-8M-XKI"/>
                             <constraint firstItem="0o8-8J-LZM" firstAttribute="top" secondItem="eM9-99-Rvk" secondAttribute="top" id="9av-xj-ZZf"/>
                             <constraint firstItem="16V-ta-42H" firstAttribute="top" secondItem="Lwf-1t-fhY" secondAttribute="bottom" constant="25" id="AMC-iv-v1o"/>
                             <constraint firstItem="0o8-8J-LZM" firstAttribute="centerY" secondItem="Lwf-1t-fhY" secondAttribute="centerY" id="AVw-6c-A2S"/>
+                            <constraint firstItem="yct-Tj-QZY" firstAttribute="top" secondItem="rBP-Ar-BpK" secondAttribute="bottom" constant="16" id="DHr-4C-QLC"/>
                             <constraint firstItem="xUd-Xg-GOt" firstAttribute="trailing" secondItem="XxU-GI-1GF" secondAttribute="trailing" id="Dz3-iw-zWY"/>
                             <constraint firstAttribute="trailingMargin" secondItem="Lwf-1t-fhY" secondAttribute="trailing" constant="4" id="Gih-xt-v2h"/>
                             <constraint firstAttribute="bottom" secondItem="xUd-Xg-GOt" secondAttribute="bottom" constant="279" id="HTH-Ab-evK"/>
                             <constraint firstAttribute="trailingMargin" secondItem="ai0-sR-Fh0" secondAttribute="trailing" constant="30" id="KCC-Ye-cC6"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="yct-Tj-QZY" secondAttribute="trailing" constant="84" id="NLn-se-68j"/>
                             <constraint firstItem="K6U-4C-ls1" firstAttribute="top" secondItem="XxU-GI-1GF" secondAttribute="bottom" constant="9" id="O2U-vZ-VZV"/>
                             <constraint firstItem="xUd-Xg-GOt" firstAttribute="leading" secondItem="XxU-GI-1GF" secondAttribute="leading" id="OLC-sT-Wl4"/>
-                            <constraint firstItem="cHE-oy-MRp" firstAttribute="centerX" secondItem="yct-Tj-QZY" secondAttribute="centerX" id="OOp-nd-kiM"/>
                             <constraint firstItem="XxU-GI-1GF" firstAttribute="centerY" secondItem="jU0-d0-NoL" secondAttribute="centerY" id="Pbl-KT-aKV"/>
-                            <constraint firstItem="rBP-Ar-BpK" firstAttribute="centerX" secondItem="GCv-8F-b0y" secondAttribute="centerX" id="R01-J4-eTw"/>
                             <constraint firstItem="QmO-J0-ddN" firstAttribute="top" secondItem="d0U-HZ-7XW" secondAttribute="bottom" constant="89" id="S2H-Qd-Flf"/>
                             <constraint firstItem="xUd-Xg-GOt" firstAttribute="top" secondItem="XxU-GI-1GF" secondAttribute="bottom" constant="8" symbolic="YES" id="VKB-n3-vVW"/>
+                            <constraint firstItem="yct-Tj-QZY" firstAttribute="centerX" secondItem="XxU-GI-1GF" secondAttribute="centerX" id="ViM-BC-4pK"/>
                             <constraint firstItem="K6U-4C-ls1" firstAttribute="centerY" secondItem="xUd-Xg-GOt" secondAttribute="centerY" id="Ylb-2Z-Sdd"/>
                             <constraint firstItem="cHE-oy-MRp" firstAttribute="top" secondItem="xUd-Xg-GOt" secondAttribute="bottom" constant="13" id="aDJ-cV-OvW"/>
                             <constraint firstItem="0o8-8J-LZM" firstAttribute="bottom" secondItem="eM9-99-Rvk" secondAttribute="bottom" id="bsu-QQ-wGT"/>
                             <constraint firstItem="cHE-oy-MRp" firstAttribute="leading" secondItem="xUd-Xg-GOt" secondAttribute="leading" id="cXd-iH-yUc"/>
-                            <constraint firstItem="rBP-Ar-BpK" firstAttribute="top" secondItem="QmO-J0-ddN" secondAttribute="bottom" constant="16" id="eEp-mv-vOy"/>
-                            <constraint firstItem="yct-Tj-QZY" firstAttribute="leading" secondItem="GCv-8F-b0y" secondAttribute="leadingMargin" constant="90" id="f9u-FL-ohh"/>
                             <constraint firstItem="0o8-8J-LZM" firstAttribute="leading" secondItem="GCv-8F-b0y" secondAttribute="leadingMargin" constant="-3" id="frr-eU-69i"/>
                             <constraint firstItem="K6U-4C-ls1" firstAttribute="leading" secondItem="jU0-d0-NoL" secondAttribute="leading" id="h9F-xc-aYi"/>
                             <constraint firstItem="xUd-Xg-GOt" firstAttribute="top" secondItem="jU0-d0-NoL" secondAttribute="bottom" constant="8" symbolic="YES" id="ihD-MF-NHH"/>
-                            <constraint firstItem="QmO-J0-ddN" firstAttribute="centerX" secondItem="rBP-Ar-BpK" secondAttribute="centerX" id="jVn-hg-ioA"/>
+                            <constraint firstItem="rBP-Ar-BpK" firstAttribute="top" secondItem="QmO-J0-ddN" secondAttribute="bottom" constant="16" id="lpG-bP-JCn"/>
                             <constraint firstItem="K6U-4C-ls1" firstAttribute="leading" secondItem="GCv-8F-b0y" secondAttribute="leadingMargin" constant="51" id="m6S-8x-cXm"/>
+                            <constraint firstItem="yct-Tj-QZY" firstAttribute="leading" secondItem="GCv-8F-b0y" secondAttribute="leadingMargin" constant="90" id="r45-xM-hhm"/>
+                            <constraint firstItem="XxU-GI-1GF" firstAttribute="top" secondItem="yct-Tj-QZY" secondAttribute="bottom" constant="25" id="sgy-83-Jub"/>
                             <constraint firstItem="eM9-99-Rvk" firstAttribute="baseline" secondItem="ai0-sR-Fh0" secondAttribute="firstBaseline" id="stn-7R-lKH"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="yct-Tj-QZY" secondAttribute="trailing" constant="84" id="tse-QX-gtf"/>
                             <constraint firstItem="cHE-oy-MRp" firstAttribute="trailing" secondItem="xUd-Xg-GOt" secondAttribute="trailing" id="uDl-ce-Cn4"/>
+                            <constraint firstItem="rBP-Ar-BpK" firstAttribute="centerX" secondItem="QmO-J0-ddN" secondAttribute="centerX" id="vXZ-QV-Wbj"/>
                             <constraint firstItem="eM9-99-Rvk" firstAttribute="leading" secondItem="GCv-8F-b0y" secondAttribute="leading" constant="49" id="za3-Na-ZuR"/>
                         </constraints>
                     </view>
@@ -981,9 +1226,9 @@
                     <navigationItem key="navigationItem" id="AaD-ys-3en"/>
                     <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
                     <connections>
-                        <segue destination="Tmz-a1-JwU" kind="custom" identifier="sw_right" customClass="SWRevealViewControllerSegueSetController" id="MuN-ZJ-8Na"/>
                         <segue destination="UGn-aw-ZLO" kind="custom" identifier="sw_front" customClass="SWRevealViewControllerSegueSetController" id="V91-AP-HmZ"/>
                         <segue destination="dNq-tu-187" kind="custom" identifier="sw_rear" customClass="SWRevealViewControllerSegueSetController" id="L1S-xE-W7o"/>
+                        <segue destination="AJj-4E-gvl" kind="custom" identifier="sw_right" customClass="SWRevealViewControllerSegueSetController" id="koT-jM-jwJ"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="laz-BX-sj8" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1037,10 +1282,11 @@
         <image name="feed_icon" width="30" height="30"/>
         <image name="grades_tab_icon" width="30" height="30"/>
         <image name="mobile_menu_icon" width="35" height="35"/>
+        <image name="profile_icon-1" width="25" height="25"/>
         <image name="school" width="640" height="360"/>
         <image name="swivel_logo" width="50" height="50"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="03S-Lg-xhu"/>
+        <segue reference="dlO-Fy-mPa"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/SwivelMobile/Info.plist
+++ b/SwivelMobile/Info.plist
@@ -52,7 +52,7 @@
 	<key>UIStatusBarHidden</key>
 	<false/>
 	<key>UIStatusBarStyle</key>
-	<string>UIStatusBarStyleDefault</string>
+	<string>UIStatusBarStyleLightContent</string>
 	<key>UIStatusBarTintParameters</key>
 	<dict>
 		<key>UINavigationBar</key>

--- a/SwivelMobile/SocketIOManager.swift
+++ b/SwivelMobile/SocketIOManager.swift
@@ -12,7 +12,7 @@ class SocketIOManager: NSObject {
     static let sharedInstance = SocketIOManager()
     
     //connect to the website
-    var socket: SocketIOClient = SocketIOClient(socketURL: NSURL(string: "http://192.168.1.XXX:3000")!)
+    var socket: SocketIOClient = SocketIOClient(socketURL: NSURL(string: "http://localhost:8080")!)
     
     //connection
     func establishConnection() {

--- a/SwivelMobile/dataStruct.swift
+++ b/SwivelMobile/dataStruct.swift
@@ -17,7 +17,7 @@ class Package {
 
     //JSON DATA
     var data: JSON?
-    var url = "http://swivelsystems.org/api/" //"http://52.39.216.194/"
+    var url = "http://localhost:8080/api/" //"http://52.39.216.194/"
     var type = "students"
     var id = 30
     var courses: [String] = []
@@ -78,8 +78,6 @@ class Package {
                 self.calculateAverage()
                 self.arrayifyAnnouncements()
                 self.arrayifyAssignments()
-
-                print(self.assignments)
             }
 
     }


### PR DESCRIPTION
Updated sidebar table controller to view controller and revamped design of
sidebar to be a chat menu and any clicks to enter a chat lobby with targeted
user. All pages have been styled properly but lack all the core functionality.
Placed the tableview and text entry point inside of a scroll view in order to
solve keyboard showing up and covering the input field.

Commits:
- Overhauled right reveal bar to be chat menu
- Complete styling for right reveal chat bar
- Created redirect when a person is clicked on chat
- Complete templating by placing tableview and text field inside scroll view
